### PR TITLE
Feature/breadcrumbs

### DIFF
--- a/src/components/BreadcrumbsNav.tsx
+++ b/src/components/BreadcrumbsNav.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Link as RouterLink } from 'react-router-dom';
+import Link from '@mui/material/Link';
+import routes from '../constants/routes';
+import Typography from '@mui/material/Typography';
+import Breadcrumbs from '@mui/material/Breadcrumbs';
+import HomeOutlinedIcon from '@mui/icons-material/HomeOutlined';
+import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
+import type { LinkProps } from '@mui/material';
+
+interface BreadcrumbsLink {
+  text: string;
+  route?: string;
+  icon?: React.ReactElement;
+}
+
+interface BreadcrumbsNavProps {
+  paths: BreadcrumbsLink[];
+}
+
+interface NavLinkProps extends LinkProps {
+  route: string;
+}
+
+function NavLink({ route, ...props }: NavLinkProps) {
+  return (
+    <Link
+      sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
+      component={RouterLink}
+      to={route}
+      color="inherit"
+      underline="hover"
+      {...props}
+    />
+  );
+}
+
+export default function BreadcrumbsNav({ paths }: BreadcrumbsNavProps) {
+  return (
+    <Breadcrumbs sx={{ px: 4 }} separator={<KeyboardArrowRightIcon fontSize="small" />}>
+      <NavLink route={routes.employees()}>
+        <HomeOutlinedIcon /> Home
+      </NavLink>
+
+      {paths.map(({ text, route, icon }, index) => {
+        const isPenult = index === paths.length - 2;
+
+        const linkInner = icon ? [icon, text] : text;
+
+        return route ? (
+          <NavLink route={route} color={isPenult ? 'primary' : 'inherit'}>
+            {linkInner}
+          </NavLink>
+        ) : (
+          <Typography>{linkInner}</Typography>
+        );
+      })}
+    </Breadcrumbs>
+  );
+}


### PR DESCRIPTION
Added an abstraction layer under MUI Breadcrumbs component.

Usage:

`<BreadcrumbsNav paths={paths} />`

.. where `paths` is an array of nodes in the breadcrumbs chain.

Examples:

```
<BreadcrumbsNav
  paths={[
    {
      text: 'Employees',
    },
  ]}
/>
```

.. will result in "Home > Employees".

```
<BreadcrumbsNav
  paths={[
    {
      text: 'Employees',
      route: routes.employees(),
    },
    {
      text: user.full_name,
      route: routes.employee(user.id),
    },
  ]}
/>
```

.. will result in "Home > Employees > Full Name".

An array item can optionally accept `icon` property ( `{ icon: <PersonOutlinedIcon /> }` ). The icon will be displayed on the left side of the text content. Only `text` field is required however.