### PR TITLE
Bugfix/users-update

### DIFF
--- a/src/apollo/operations/employees.ts
+++ b/src/apollo/operations/employees.ts
@@ -1,59 +1,65 @@
 import { gql } from '@apollo/client';
 
+const USER_DATA = gql`
+  fragment UserData on User {
+    department_name
+    position_name
+    department {
+      id
+    }
+    position {
+      id
+    }
+  }
+`;
+
+const PROFILE_DATA = gql`
+  fragment ProfileData on Profile {
+    id
+    first_name
+    last_name
+    full_name
+    avatar
+    skills {
+      skill_name
+      mastery
+    }
+    languages {
+      language_name
+      proficiency
+    }
+  }
+`;
+
 export const GET_USERS = gql`
+  ${USER_DATA}
+  ${PROFILE_DATA}
   query GetUsers {
     users {
+      ...UserData
       id
       created_at
       email
-      department_name
-      position_name
       role
-      department {
-        id
-      }
-      position {
-        id
-      }
       cvs {
         id
         name
       }
       profile {
-        id
-        first_name
-        last_name
-        full_name
-        avatar
-        skills {
-          skill_name
-          mastery
-        }
-        languages {
-          language_name
-          proficiency
-        }
+        ...ProfileData
       }
     }
   }
 `;
 
 export const UPDATE_USER = gql`
+  ${USER_DATA}
+  ${PROFILE_DATA}
   mutation UpdateUser($id: ID!, $user: UpdateUserInput!) {
     updateUser(id: $id, user: $user) {
-      id
-      department_name
-      position_name
+      ...UserData
       profile {
-        first_name
-        last_name
-        full_name
-      }
-      department {
-        id
-      }
-      position {
-        id
+        ...ProfileData
       }
     }
   }

--- a/src/apollo/operations/employees.ts
+++ b/src/apollo/operations/employees.ts
@@ -42,6 +42,8 @@ export const UPDATE_USER = gql`
   mutation UpdateUser($id: ID!, $user: UpdateUserInput!) {
     updateUser(id: $id, user: $user) {
       id
+      department_name
+      position_name
       profile {
         first_name
         last_name

--- a/src/components/profile/ProfileUpdateForm.tsx
+++ b/src/components/profile/ProfileUpdateForm.tsx
@@ -75,18 +75,8 @@ export default function ProfileUpdateForm({ readOnly }: FormProps) {
         },
       },
     });
-    const result = data.updateUser;
-    const { first_name, last_name, full_name } = result.profile;
-    dispatch(
-      updateUser({
-        id: result.id,
-        changes: {
-          profile: { ...user.profile, first_name, last_name, full_name },
-          department: { id: result.department?.id } as Department,
-          position: { id: result.position?.id } as Position,
-        },
-      }),
-    );
+    const changes = data.updateUser;
+    dispatch(updateUser({ id: user.id, changes }));
   };
 
   const TextInput = useCallback(


### PR DESCRIPTION
Fixed incorrect 'employees table' update after successful user profile mutation.
The table relies on `department_name` and `position_name` fields that were not initially requested to be in the mutate function's return data. 